### PR TITLE
feat(ci): add Teams notification on push to develop

### DIFF
--- a/.github/workflows/notify-teams.yml
+++ b/.github/workflows/notify-teams.yml
@@ -1,0 +1,26 @@
+name: Notify Dev Team on develop push
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Dev Team via Power Automate
+        run: |
+          curl -X POST "${{ secrets.DEV_MERGE_TEAMS_URL}}" \
+               -H "Content-Type: application/json" \
+               -d @- <<EOF
+          {
+            "repository": "${{ github.repository }}",
+            "ref": "${{ github.ref }}",
+            "pusher": {
+              "name": "${{ github.actor }}"
+            },
+            "head_commit": {
+              "message": "${{ github.event.head_commit.message }}"
+            }
+          }


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

- In GitFlow, `develop` is the main integration branch where feature branches are regularly merged.
- Developers working on long-lived feature branches can easily fall out of sync with `develop`.
- This notification ensures the team is immediately aware when `develop` changes — encouraging timely rebases and reducing the likelihood of complex merge conflicts later.

## Description

- Introduces a GitHub Actions workflow that sends a notification to Microsoft Teams when a push is made to the `develop` branch. It integrates with a Power Automate flow via a secure HTTP POST request.
- GitHub secret `DEV_MERGE_TEAMS_URL` configured

## How Has This Been Tested?

- test locally with `curl` 

## Screenshots (if appropriate):
<img width="917" alt="image" src="https://github.com/user-attachments/assets/dae12df8-9a93-41f3-9d2a-f31e346b51e1" />

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The base branch of this PR is set to **develop**
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

