### PR TITLE
feat(ci): Add checklist item to PR template for targeting 'develop' branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] The base branch is set to `develop`
 - [ ] It contains only changes required by issue (does not contain other PR)
 - [ ] Includes link to an issue (if apply)
 - [ ] I have added tests to cover my changes.


### PR DESCRIPTION
## Sensitive Credential Checks

- [x] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. --> 
NDTP is keen to keep `main` as the default branch. Our workflow requires all PRs to target the `develop` branch instead of the default (`main`),  GitHub does not currently allow us to change the default base branch for PRs. This checklist item helps prevent mistakes and standardises our PR process.


## Description

- Adds a checklist item to the pull request template to remind contributors to set the base branch to **develop** when opening a PR.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
<!--- How does your change affect other areas of the code, etc. -->
- n/a

## Screenshots (if appropriate):
- n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The base branch is set to **develop**
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes link to an issue (if apply)
- [x] I have added tests to cover my changes.

