### PR TITLE
feat(ci): automate SNAPSHOT version updates in develop post-release

### DIFF
--- a/.github/workflows/gitflow-next-snapshot-version.yml
+++ b/.github/workflows/gitflow-next-snapshot-version.yml
@@ -1,0 +1,67 @@
+name: Update Develop to SNAPSHOT Version
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger only when release tags v* are pushed (e.g., v1.2.0)
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed to push to develop branch
+
+    steps:
+      - name: Checkout develop branch
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Get release tag version
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          with_v: false  # Returns version without 'v' prefix
+
+      - name: Calculate next SNAPSHOT version
+        id: version_calc
+        run: |
+          # Parse the version components (1.2.0 → 1.2.1-SNAPSHOT)
+          IFS='.' read -ra VERSION_PARTS <<< "${{ steps.tag_version.outputs.new_version }}"
+          MAJOR=${VERSION_PARTS[0]}
+          MINOR=${VERSION_PARTS[1]}
+          PATCH=${VERSION_PARTS[2]}
+          
+          # Increment patch version by convention
+          NEXT_PATCH=$((PATCH + 1))
+          NEXT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
+          
+          echo "Next version: $NEXT_VERSION"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update POM version
+        run: |
+          mvn versions:set -DnewVersion=${{ steps.version_calc.outputs.NEXT_VERSION }}
+          mvn versions:commit  # Clean up backup files
+
+      - name: Commit and push version update
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git add pom.xml
+          git commit -m "Update to ${{ steps.version_calc.outputs.NEXT_VERSION }} [skip ci]"
+          git pull --rebase  # Handle potential concurrent changes
+          git push origin develop
+
+      - name: Verify the update
+        run: |
+          echo "Version updated to:"
+          mvn help:evaluate -Dexpression=project.version -q -DforceStdout


### PR DESCRIPTION
## TODO

- restrict Tag Creation to GitHub Actions Only

## Sensitive Credential Checks

- [ ] As the author of these changes, I have checked for any sensitive credentials prior to this review being requested.
- [ ] As a reviewer of these changes, I have checked for any sensitive credentials prior to approving this merge.

<!--- When merging the branch to dev please use the SQUASH AND MERGE --->

## Motivation and Context

- Automatically updates the `pom.xml` version in the `develop` branch to the next `-SNAPSHOT` version after a release (e.g., `1.2.0` → `1.2.1-SNAPSHOT`).  
- Developers: No longer need to manually bump versions after releases.
- CI/CD: Ensures `develop` always reflects the next planned version.

## Description

- Add GitHub Action to bump version to next SNAPSHOT post-release
- Trigger on new version tags (v*)
- Update POM version and push to `develop` branch

## How Has This Been Tested?

- Manually tested by simulating a tag push:  
   ```bash
   git tag v1.2.0-test && git push origin v1.2.0-test
   ```
- Verified:
- `develop` branch’s pom.xml updated to 1.2.1-SNAPSHOT.
- Commit is signed and tagged properly.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The base branch is set to `develop`
- [x] It contains only changes required by issue (does not contain other PR)

